### PR TITLE
Add support for CC label to the checkin command ( --cclabel switch )

### DIFF
--- a/README
+++ b/README
@@ -62,6 +62,14 @@ very first commit to HEAD), mark the start point with the command:
 
 gitcc tag <commit>
 
+To specify an existing Clearcase label while checking in, in order to let your
+dynamic view show the version of the element(s) just checked in if your
+confspec is configured accordingly, use the command:
+
+gitcc checkin --cclabel=YOUR_EXISTING_CC_LABEL
+
+Note that the CC label will be moved to the new version of the element, if it is already used.
+
 Configuration
 =============
 

--- a/checkin.py
+++ b/checkin.py
@@ -10,17 +10,22 @@ import cache, reset
 
 IGNORE_CONFLICTS=False
 LOG_FORMAT = '%H%x01%s%n%b'
+CC_LABEL = ''
 
 ARGS = {
     'force': 'ignore conflicts and check-in anyway',
     'no_deliver': 'do not deliver in UCM mode',
     'initial': 'checkin everything from the beginning',
     'all': 'checkin all parents, not just the first',
+    'cclabel': 'optionally specify an existing Clearcase label type to apply to each element checked in',
 }
 
-def main(force=False, no_deliver=False, initial=False, all=False):
+def main(force=False, no_deliver=False, initial=False, all=False, cclabel=''):
     validateCC()
     global IGNORE_CONFLICTS
+    global CC_LABEL
+    if cclabel:
+	    CC_LABEL=cclabel
     if force:
         IGNORE_CONFLICTS=True
     cc_exec(['update', '.'], errors=False)
@@ -92,11 +97,14 @@ def checkout(stats, comment, initial):
 class ITransaction(object):
     def __init__(self, comment):
         self.checkedout = []
+        self.cc_label = CC_LABEL
         cc.mkact(comment)
     def add(self, file):
         self.checkedout.append(file)
     def co(self, file):
         cc_exec(['co', '-reserved', '-nc', file])
+        if CC_LABEL:
+            cc_exec(['mklabel', '-replace', '-nc', CC_LABEL, file])
         self.add(file)
     def stageDir(self, file):
         file = file if file else '.'

--- a/status.py
+++ b/status.py
@@ -22,6 +22,8 @@ class Status:
             dir = self.dirs.pop();
             if not exists(join(CC_DIR, dir)):
                 cc_exec(['mkelem', '-nc', '-eltype', 'directory', dir])
+                if t.cc_label:
+                    cc_exec(['mklabel', '-nc', t.cc_label, dir])				
                 t.add(dir)
 
 class Modify(Status):
@@ -37,6 +39,8 @@ class Add(Status):
         self.commitDirs(t)
         self.cat()
         cc_exec(['mkelem', '-nc', self.file])
+        if t.cc_label:
+            cc_exec(['mklabel', '-nc', t.cc_label, self.file])	
         t.add(self.file)
 
 class Delete(Status):


### PR DESCRIPTION
... to be able to specify an existing Clearcase label while checking in, in order to let the dynamic view show the version of the element(s) just checked in if the confspec is configured accordingly. The CC label will be moved to the new version of the element, if it is already used.
