### PR TITLE
Fix missing empty line in commit message during gitcc checkin

### DIFF
--- a/checkin.py
+++ b/checkin.py
@@ -9,7 +9,7 @@ from os.path import isdir
 import cache, reset
 
 IGNORE_CONFLICTS=False
-LOG_FORMAT = '%H%x01%s%n%b'
+LOG_FORMAT = '%H%x01%B'
 CC_LABEL = ''
 
 ARGS = {


### PR DESCRIPTION
Fixes #44.
The empty line is missing while parsing git log and then commiting to CC.
Fix git log format to print extra new line (%n) after subject (%s).
