### PR TITLE
fix filename and version detection

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -83,7 +83,7 @@ class CCFile(object):
 
 class CCFile2(CCFile):
     def __init__(self, line):
-        [file, version] = line.split('@@')
+        [file, version] = line.rsplit('@@', 1)
         super(CCFile2, self).__init__(file, version)
 
 class Version(object):


### PR DESCRIPTION
When filename contains '@@' the split will return more then two elements. In this case we'll got ValueError. 
To avoid that we need to split on the last occurrence of '@@'.
