### PR TITLE
Fix "gitcc rebase" for empty files 

### DIFF
--- a/rebase.py
+++ b/rebase.py
@@ -250,37 +250,38 @@ class Uncataloged(Changeset):
                     continue
                 history = filter(None, history.split('\n'))
                 all_versions = self.parse_history(history)
-                date = cc_exec(['describe', '-fmt', '%Nd', dir])
 
-                versions = self.checkin_versions(all_versions, date)
+                date = cc_exec(['describe', '-fmt', '%Nd', dir])
+                actual_versions = self.filter_versions(all_versions, lambda x: x[1] < date)
+
+                versions = self.checkin_versions(actual_versions)
                 if not versions:
                     print("No proper versions of '%s' file. Check if it is empty." % added)
-                    versions = self.empty_file_versions(all_versions, date)
+                    versions = self.empty_file_versions(actual_versions)
                 if not versions:
                     print("It appears that you may be missing a branch in the includes section of your gitcc config for file '%s'." % added)
                     continue
                 self._add(added, versions[0][2].strip())
 
-    def checkin_versions(self, versions, date):
-        return self.filter_versions_by_type(versions, date, 'checkinversion')
+    def checkin_versions(self, versions):
+        return self.filter_versions_by_type(versions, 'checkinversion')
 
-    def empty_file_versions(self, versions, date):
-        versions = self.filter_versions(versions, lambda x: x[1] < date)
-        return self.versions_with_branch(versions, date) or self.versions_without_branch(versions, date)
+    def empty_file_versions(self, versions):
+        return self.versions_with_branch(versions) or self.versions_without_branch(versions)
 
-    def versions_with_branch(self, versions, date):
+    def versions_with_branch(self, versions):
         if len(versions) != 5:
             return False
-        return self.filter_versions_by_type(versions, date, 'mkbranchversion')
+        return self.filter_versions_by_type(versions, 'mkbranchversion')
 
-    def versions_without_branch(self, versions, date):
+    def versions_without_branch(self, versions):
         if len(versions) != 3:
             return False
         return self.filter_versions(versions, lambda x: x[0] == 'mkelemversion')
 
-    def filter_versions_by_type(self, versions, date, type):
+    def filter_versions_by_type(self, versions, type):
         def f(s):
-            return s[0] == type and s[1] < date and filterBranches(s[2], True)
+            return s[0] == type and filterBranches(s[2], True)
         return self.filter_versions(versions, f)
 
     def filter_versions(self, versions, handler):


### PR DESCRIPTION
For files that had been checked in initially empty.

Fixes #20.
The existing fix in charleso/git-cc@ccf628d is not working.

Solution:
If there is no "checkinversion" in "lshistory" then check if there is
3 items in the history (mkelemfile, mkelembranch, mkelemversion)
or 5 items (mkelemfile, mkelembranch, mkelemversion, mkbranchbranch, mkbranchversion)
If so then this file is created as an empty one and download it with proper version.
