### PR TITLE
Fix "gitcc rebase" for new files in a folder

### DIFF
--- a/rebase.py
+++ b/rebase.py
@@ -229,6 +229,9 @@ class Changeset(object):
 
 class Uncataloged(Changeset):
     def add(self, files):
+        cc_dir = join(CC_DIR, self.file)
+        cc_exec(["update", cc_dir])
+
         dir = path(cc_file(self.file, self.version))
         diff = cc_exec(['diff', '-diff_format', '-pred', dir], errors=False)
         def getFile(line):


### PR DESCRIPTION
New files in a dir were filtered (rebase.py:249) and were not added because
they didn't exist yet in a CC view until performing Update in ClearCase
Explorer.

Perform "cleartool update" for each "checkindirectory version" folder
to get all its files in the CC view to allow retrieve lshistory on new files
properly.
