### PR TITLE
Make `update` for the whole project dir instead of each updated dir

### DIFF
--- a/rebase.py
+++ b/rebase.py
@@ -31,6 +31,9 @@ def main(stash=False, dry_run=False, lshistory=False, load=None):
     validateCC()
     if not (stash or dry_run or lshistory):
         checkPristine()
+
+    cc_exec(["update"])
+
     since = getSince()
     cache.start()
     if load:
@@ -229,9 +232,6 @@ class Changeset(object):
 
 class Uncataloged(Changeset):
     def add(self, files):
-        cc_dir = join(CC_DIR, self.file)
-        cc_exec(["update", cc_dir])
-
         dir = path(cc_file(self.file, self.version))
         diff = cc_exec(['diff', '-diff_format', '-pred', dir], errors=False)
         def getFile(line):


### PR DESCRIPTION
Alter pull request #49.

There were still issues with `gitcc rebase` and new files in several
subdirs. `lshistory` for such elements is reversed i.e. subdirs first
and then parent dirs.
