### PR TITLE
Adds a test file that should have been in...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Emacs
 *~
+*#
 
 # Python
-users.py
 *.pyc
+build/
+dist/
+git_cc.egg-info/

--- a/tests/user-config/users.py
+++ b/tests/user-config/users.py
@@ -1,0 +1,6 @@
+users = {
+    'charleso': "Charles O'Farrell",\
+    'jki': 'Jan Kiszka <jan.kiszka@web.de>',\
+}
+
+mailSuffix = 'example.com'


### PR DESCRIPTION
Oops, sorry about this one, but the unit tests depend on a file I forgot to add to the repo.

Without the changes in this pull request, if you run the unit tests in the repo:

    git-cc $ python -m unittest discover tests/

you will have failing tests. With the changes in this pull request, all tests pass.

To avoid these kind of issues, I am preparing a pull request that adds support for [tox](http://tox.readthedocs.io/en/latest/). Tox creates a source installer for a package, installs it in a virtualenv and runs the tests. Would I have used Tox, I would have detected the issue.