### PR TITLE
Fix issue #91 DEBUG in common.py dealt as str after loaded from config file

### DIFF
--- a/git_cc/common.py
+++ b/git_cc/common.py
@@ -225,7 +225,7 @@ CURRENT_BRANCH = getCurrentBranch() or 'master'
 cfg = GitConfigParser(CURRENT_BRANCH)
 cfg.read()
 CC_DIR = path(cfg.get(CFG_CC))
-DEBUG = cfg.getCore('debug', True)
+DEBUG = str(cfg.getCore('debug', True)) == str(True)
 CC_TAG = CURRENT_BRANCH + '_cc'
 CI_TAG = CURRENT_BRANCH + '_ci'
 users = get_users_module(cfg.getUsersModulePath())


### PR DESCRIPTION
Hi Charles,

You are right, it's better to be one line and to be safer by adding `str()` on both sides. (Actually, I am a beginner of Python and using your git-cc as my textbook for learning Python)

Besides, in order to reduce commit log, I reset the just now commit and commit again.

My apologizes that previous pull request was my 1st pull request on Github, and I am not so familiar with Github usage: I found that your comment disappeared along with the deleting of my previous commit...

Cheers,
oplier
